### PR TITLE
add nil to the call as it's failing to compile

### DIFF
--- a/input.go
+++ b/input.go
@@ -80,7 +80,7 @@ func (rpsi *RedisPubSubInput) Run(ir pipeline.InputRunner, h pipeline.PluginHelp
 				if e != nil {
 					ir.LogError(fmt.Errorf("Couldn't parse Redis message: %s", n.Data))
 				}
-				pack.Recycle()
+				pack.Recycle(nil)
 			}
 		case redis.Subscription:
 			ir.LogMessage(fmt.Sprintf("Subscription: %s %s %d\n", n.Kind, n.Channel, n.Count))


### PR DESCRIPTION
go stops compiling throwing a `not enough arguments in call to pack.Recycle`

This fixes #3 
